### PR TITLE
Refactor to allow instantiating a PCO::URL object, add encrypted query parameters functionality

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  ruby:
+    version: 2.2.1

--- a/lib/pco/url.rb
+++ b/lib/pco/url.rb
@@ -1,6 +1,6 @@
 require "pco/url/version"
 require "uri"
-require "urlcrypt"
+require "URLcrypt"
 
 module PCO
   class URL

--- a/lib/pco/url.rb
+++ b/lib/pco/url.rb
@@ -15,10 +15,7 @@ module PCO
 
           if uri.query
             if encrypted_part = encrypted_query_string(uri.query)
-              uri.query = uri.query.gsub("_e=" + encrypted_part, "")
-              uri.query = uri.query[1..-1] if uri.query[0] == "&"
-              uri.query += "&" unless uri.query.empty?
-              uri.query += decrypt_query_params(encrypted_part)
+              uri.query.sub!("_e=#{encrypted_part}", decrypt_query_params(encrypted_part))
             end
           end
 

--- a/lib/pco/url.rb
+++ b/lib/pco/url.rb
@@ -12,7 +12,7 @@ module PCO
 
       def method_missing(method_name, *args)
         path = args.map { |p| p.sub(/\A\/+/, "").sub(/\/+\Z/, "") }.join("/")
-        new(method_name, path).to_s
+        new(app_name: method_name, path: path).to_s
       end
     end
 
@@ -20,12 +20,12 @@ module PCO
     attr_reader :path
     attr_reader :query
 
-    def initialize(app_name, path = nil, query = nil, options = {})
+    def initialize(app_name:, path: nil, query: nil, encrypt_query_params: false)
       @app_name       = app_name.to_s.gsub("_", "-")
       @path           = path
 
       if query
-        @query = options[:encrypt_query_params] ? URLcrypt.encrypt(query) : query
+        @query = encrypt_query_params ? URLcrypt.encrypt(query) : query
       end
     end
 

--- a/lib/pco/url.rb
+++ b/lib/pco/url.rb
@@ -1,48 +1,81 @@
 require "pco/url/version"
-require 'uri'
+require "uri"
+require "urlcrypt"
 
 module PCO
   class URL
 
     class << self
+      def decrypt_query_params(string)
+        URLcrypt.decrypt(string)
+      end
+
       def method_missing(method_name, *args)
-        url_for_app_with_path(method_name, args)
-      end
-
-      private
-
-      def env
-        ENV["DEPLOY_ENV"] || Rails.env
-      end
-
-      def env_url(app_name)
-        env_var  = app_name.to_s.upcase + "_URL"
-        ENV[env_var]
-      end
-
-      def url_for_app_with_path(app_name, paths)
-        path = paths.map { |p| p.sub(/\A\/+/, "").sub(/\/+\Z/, "") }.join("/")
-
-        URI::join(url_for_app(app_name), path).to_s
-      end
-
-      def url_for_app(app_name)
-        # Try "CHECK_INS_URL" then url_for_app("check-ins")
-        return env_url(app_name) if env_url(app_name)
-
-        app_name = app_name.to_s.gsub("_", "-")
-        case env
-        when "production"
-          "https://#{app_name}.planningcenteronline.com"
-        when "staging"
-          "https://#{app_name}-staging.planningcenteronline.com"
-        when "development"
-          "http://#{app_name}.pco.dev"
-        when "test"
-          "http://#{app_name}.pco.test"
-        end
+        path = args.map { |p| p.sub(/\A\/+/, "").sub(/\/+\Z/, "") }.join("/")
+        new(method_name, path).to_s
       end
     end
 
+    attr_reader :app_name
+    attr_reader :path
+    attr_reader :query
+
+    def initialize(app_name, path = nil, query = nil, options = {})
+      @app_name       = app_name.to_s.gsub("_", "-")
+      @path           = path
+
+      if query
+        @query = options[:encrypt_query_params] ? URLcrypt.encrypt(query) : query
+      end
+    end
+
+    def scheme
+      # Try "CHECK_INS_URL" then url_for_app("check-ins")
+      return env_overridden_hostname.split("://")[0] if env_overridden_hostname
+
+      case env
+      when "production", "staging"
+        "https"
+      else
+        "http"
+      end
+    end
+
+    def hostname
+      # Try "CHECK_INS_URL" then url_for_app("check-ins")
+      return env_overridden_hostname.split("://")[1] if env_overridden_hostname
+
+      case env
+      when "production"
+        "#{@app_name}.planningcenteronline.com"
+      when "staging"
+        "#{@app_name}-staging.planningcenteronline.com"
+      when "development"
+        "#{@app_name}.pco.dev"
+      when "test"
+        "#{@app_name}.pco.test"
+      end
+    end
+
+    def uri
+      query = @query ? "?#{@query}" : nil
+      url_string = "#{scheme}://#{hostname}/#{@path}#{query}".sub(/(\/)+$/,'')
+      URI(url_string)
+    end
+
+    def to_s
+      uri.to_s
+    end
+
+    private
+
+    def env
+      ENV["DEPLOY_ENV"] || Rails.env
+    end
+
+    def env_overridden_hostname
+      env_var = @app_name.to_s.upcase + "_URL"
+      ENV[env_var]
+    end
   end
 end

--- a/pco-url.gemspec
+++ b/pco-url.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = PCO::URL::VERSION
   spec.authors       = ["James Miller"]
   spec.email         = ["bensie@gmail.com"]
-  spec.summary       = %q{Generate URLs for app PCO apps in all environments}
+  spec.summary       = %q{Generate URLs for PCO apps in all environments}
   spec.homepage      = "https://github.com/ministrycentered/pco-url"
   spec.license       = "MIT"
 
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "urlcrypt", ">= 0.1.1"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", ">= 3.0.0", "< 4"

--- a/spec/pco_url_spec.rb
+++ b/spec/pco_url_spec.rb
@@ -127,4 +127,24 @@ describe PCO::URL do
     end
   end
 
+  describe "encrypted params" do
+    subject { PCO::URL.new("people", nil, "foo=bar", encrypt_query_params: true) }
+
+    before(:all) do
+      URLcrypt.key = "superdupersecretsuperdupersecret"
+    end
+
+    it "encrypts URL parameters" do
+      expect(subject.query).to_not eq("foo=bar")
+    end
+
+    it "encrypts and decrypts URL parameters" do
+      expect(URLcrypt.decrypt(subject.query)).to eq("foo=bar")
+    end
+
+    it "decrypts using #decrypt_query_params" do
+      expect(PCO::URL.decrypt_query_params(subject.query)).to eq("foo=bar")
+    end
+  end
+
 end

--- a/spec/pco_url_spec.rb
+++ b/spec/pco_url_spec.rb
@@ -128,7 +128,7 @@ describe PCO::URL do
   end
 
   describe "encrypted params" do
-    subject { PCO::URL.new("people", nil, "foo=bar", encrypt_query_params: true) }
+    subject { PCO::URL.new(app_name: "people", query: "foo=bar", encrypt_query_params: true) }
 
     before(:all) do
       URLcrypt.key = "superdupersecretsuperdupersecret"

--- a/spec/pco_url_spec.rb
+++ b/spec/pco_url_spec.rb
@@ -205,7 +205,7 @@ describe PCO::URL do
         subject { PCO::URL.parse(pco_url.to_s + "&foo=bar") }
 
         it "decrypts the encrypted portion and appends the unencrypted portion" do
-          expect(subject.query).to eq('foo=bar&full_access=1&total_control=1')
+          expect(subject.query).to eq('full_access=1&total_control=1&foo=bar')
         end
       end
     end

--- a/spec/pco_url_spec.rb
+++ b/spec/pco_url_spec.rb
@@ -7,10 +7,15 @@ Applications = [
   :check_ins,
   :people,
   :registrations,
-  :resources
+  :resources,
+  :giving
 ]
 
 describe PCO::URL do
+  before :all do
+    URLcrypt.key = "984e9002e680dc9b9c2556434c47f7e4782191f52063277901e4a009797652e08f28be069dfb4d4a1e3c9ab09fedab59be2c9b6486748bf44030182815ee4987"
+  end
+
   describe "defaults" do
     describe "development" do
       before do
@@ -130,10 +135,6 @@ describe PCO::URL do
   describe "encrypted params" do
     subject { PCO::URL.new(app_name: "people", query: "foo=bar", encrypt_query_params: true) }
 
-    before(:all) do
-      URLcrypt.key = "superdupersecretsuperdupersecret"
-    end
-
     it "encrypts URL parameters" do
       expect(subject.query).to_not eq("foo=bar")
     end
@@ -143,27 +144,23 @@ describe PCO::URL do
     end
 
     it "encrypts and decrypts URL parameters" do
-      expect(URLcrypt.decrypt(subject.query)).to eq("foo=bar")
+      expect(URLcrypt.decrypt(subject.query.gsub("_e=", ""))).to eq("foo=bar")
     end
 
     it "decrypts using #decrypt_query_params" do
-      expect(PCO::URL.decrypt_query_params(subject.query)).to eq("foo=bar")
+      expect(PCO::URL.decrypt_query_params(subject.query.gsub("_e=", ""))).to eq("foo=bar")
     end
   end
 
   describe '.parse' do
-    let(:subject) { PCO::URL.parse("https://people-staging.planningcenteronline.com") }
-
-    before(:all) do
-      URLcrypt.key = "superdupersecretsuperdupersecret"
-    end
+    subject { PCO::URL.parse("https://people-staging.planningcenteronline.com") }
 
     it 'returns a PCO::URL object' do
       expect(subject.class).to eq(PCO::URL)
     end
 
     context 'when only a url string is passed' do
-      let(:subject) { PCO::URL.parse("http://people.pco.dev") }
+      subject { PCO::URL.parse("http://people.pco.dev") }
 
       it 'sets the app_name attr' do
         expect(subject.app_name).to eq('people')
@@ -176,7 +173,7 @@ describe PCO::URL do
     end
 
     context 'when a string and path is passed' do
-      let(:subject) { PCO::URL.parse("https://people.planningcenteronline.com/households/2.json") }
+      subject { PCO::URL.parse("https://people.planningcenteronline.com/households/2.json") }
 
       it 'sets the app_name and path attrs' do
         expect(subject.app_name).to eq('people')
@@ -185,21 +182,30 @@ describe PCO::URL do
     end
 
     context 'when a string, path and query are passed' do
-      let(:subject) { PCO::URL.parse("https://people.planningcenteronline.com/households/2.html?full_access=1&staff=1") }
+      let(:pco_url) { PCO::URL.new(app_name: :people, path: 'households/2.html', query: 'full_access=1&total_control=1', encrypt_query_params: true) }
+
+      subject { PCO::URL.parse("https://people.planningcenteronline.com/households/2.html?full_access=1&total_control=1") }
 
       it 'sets the app_name, path, and query attrs' do
         expect(subject.app_name).to eq('people')
         expect(subject.path).to eq('/households/2.html')
-        expect(subject.query).to eq('full_access=1&staff=1')
+        expect(subject.query).to eq('full_access=1&total_control=1')
       end
 
       context 'when the query is encrypted' do
-        let(:pcourl) { PCO::URL.new(app_name: :people, path: 'households/2.html', query: 'full_access=1&staff=1', encrypt_query_params: true) }
-        let(:subject) { PCO::URL.parse(pcourl.to_s) }
+        subject { PCO::URL.parse(pco_url.to_s) }
 
         it 'first decrypts the query' do
-          expect(pcourl.query).not_to eq('full_access=1&staff=1')
-          expect(subject.query).to eq('full_access=1&staff=1')
+          expect(pco_url.query).not_to eq('full_access=1&total_control=1')
+          expect(subject.query).to eq('full_access=1&total_control=1')
+        end
+      end
+
+      context "when part of the query string is encrypted" do
+        subject { PCO::URL.parse(pco_url.to_s + "&foo=bar") }
+
+        it "decrypts the encrypted portion and appends the unencrypted portion" do
+          expect(subject.query).to eq('foo=bar&full_access=1&total_control=1')
         end
       end
     end


### PR DESCRIPTION
This PR maintains backward compatible API with the `PCO::URL.people` method missing style URL builder, but this adds a `PCO::URL.new` initializer and object that makes things a bit more flexible.

This also adds the ability to encrypt/decrypt query parameters and pass then between our apps, provided that each app uses the same `URLcrypt.key = "foo"` key.