### PR TITLE
feature(secret message passing extension)

### DIFF
--- a/lib/pco/encryption.rb
+++ b/lib/pco/encryption.rb
@@ -1,0 +1,29 @@
+require 'active_support/all'
+require 'pco/encryption/strategy_url_crypt'
+require 'pco/encryption/strategy_message_verifier'
+
+module PCO
+  class Encryption
+    class << self
+      def encrypt(message, strategy: StrategyUrlCrypt.new)
+        strategy.encrypt(message)
+      end
+
+      def decrypt(message)
+        decrypt_via_url_crypt(message) || decrypt_via_message_verifier(message)
+      end
+
+      def decrypt_via_url_crypt(message, strategy: StrategyUrlCrypt.new)
+        strategy.decrypt(message)
+      rescue URLcrypt::DecryptError, OpenSSL::Cipher::CipherError
+        nil
+      end
+
+      def decrypt_via_message_verifier(message, strategy: StrategyMessageVerifier.new)
+        strategy.decrypt(message)
+      rescue ActiveSupport::MessageVerifier::InvalidSignature
+        nil
+      end
+    end
+  end
+end

--- a/lib/pco/encryption/strategy_message_verifier.rb
+++ b/lib/pco/encryption/strategy_message_verifier.rb
@@ -1,0 +1,16 @@
+require 'rack'
+require 'active_support/all'
+
+class StrategyMessageVerifier
+  def initialize
+    @verifier = ActiveSupport::MessageVerifier.new('sekrit')
+  end
+
+  def encrypt(message)
+    Rack::Utils.escape_path(@verifier.generate(message))
+  end
+
+  def decrypt(signed_token)
+    @verifier.verify(Rack::Utils.unescape(signed_token).gsub(/ /, ''))
+  end
+end

--- a/lib/pco/encryption/strategy_url_crypt.rb
+++ b/lib/pco/encryption/strategy_url_crypt.rb
@@ -1,0 +1,15 @@
+require "URLcrypt"
+
+class StrategyUrlCrypt
+  def initialize()
+    URLcrypt.key = "984e9002e680dc9b9c2556434c47f7e4782191f52063277901e4a009797652e08f28be069dfb4d4a1e3c9ab09fedab59be2c9b6486748bf44030182815ee4987"
+  end
+
+  def encrypt(message)
+    URLcrypt.encrypt(message)
+  end
+
+  def decrypt(message)
+    URLcrypt.decrypt(message)
+  end
+end

--- a/lib/pco/url.rb
+++ b/lib/pco/url.rb
@@ -1,12 +1,11 @@
 require "pco/url/version"
 require "uri"
-require "URLcrypt"
 
 module PCO
   class URL
     class << self
       def decrypt_query_params(string)
-        URLcrypt.decrypt(string)
+        PCO::Encryption.decrypt(string)
       end
 
       def parse(string)
@@ -55,7 +54,7 @@ module PCO
       @path = @path[1..-1] if @path && @path[0] == "/"
 
       if query
-        @query = encrypt_query_params ? "_e=#{URLcrypt.encrypt(query)}" : query
+        @query = encrypt_query_params ? "_e=#{PCO::Encryption.encrypt(query, strategy: StrategyUrlCrypt.new)}" : query
       end
     end
 

--- a/pco-url.gemspec
+++ b/pco-url.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "urlcrypt", ">= 0.1.1"
+  spec.add_runtime_dependency "activesupport", ">= 4.1"
+  spec.add_runtime_dependency "rack", "~> 1.6.0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", ">= 3.0.0", "< 4"

--- a/spec/encryption_spec.rb
+++ b/spec/encryption_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe PCO::Encryption do
+  let(:message) { 'hello world' }
+  describe 'encrypt' do
+    context 'of a urlcrypt message' do
+      let(:encrypted_message) { PCO::Encryption.encrypt(message, strategy: StrategyUrlCrypt.new) }
+      it 'should be different than plaintext' do
+        expect(encrypted_message).not_to eq(message)
+      end
+      it 'should be reversible via fallthrough strategy' do
+        expect(PCO::Encryption.decrypt(encrypted_message)).to eq(message)
+      end
+    end
+    context 'of a verified message' do
+      let(:encrypted_message) { PCO::Encryption.encrypt(message, strategy: StrategyMessageVerifier.new) }
+      it 'should be different than plaintext' do
+        expect(encrypted_message).not_to eq(message)
+      end
+      it 'should be reversible via fallthrough strategy' do
+        expect(PCO::Encryption.decrypt(encrypted_message)).to eq(message)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "rspec"
 require "pco/url"
+require "pco/encryption"
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
NOT READY

This is just to aid discussion.

At it's core, it allows us to change between encoding/encrypting/secret_message_passing algorithms while still having our decoder be backwards compatible.

As it support `MessageVerifier` it pulls in a dependency of Rails 4.1.