### PR TITLE
Allow _e encrypted param to be accompanied by unencrypted params

### DIFF
--- a/lib/pco/url.rb
+++ b/lib/pco/url.rb
@@ -46,7 +46,7 @@ module PCO
       end
 
       def encrypted_params_regex
-        /^_e=(?<param>[^\&]*)/
+        /\b_e=(?<param>[^\&]*)/
       end
     end
 

--- a/lib/pco/url/version.rb
+++ b/lib/pco/url/version.rb
@@ -1,5 +1,5 @@
 module PCO
   class URL
-    VERSION = "1.7.0"
+    VERSION = "1.7.1"
   end
 end

--- a/spec/pco_url_spec.rb
+++ b/spec/pco_url_spec.rb
@@ -257,6 +257,22 @@ describe PCO::URL do
           )
         end
       end
+
+      context "when the encrypted part of the query string is not first" do
+        let(:url) { pco_url.to_s.sub(/\?(_e=.+)/, "?foo=bar&\\1") }
+
+        subject { PCO::URL.parse(url) }
+
+        it "decrypts the encrypted portion and includes the unencrypted portion" do
+          expect(subject.query).to eq("foo=bar&full_access=1&total_control=1")
+        end
+
+        it "returns the full url" do
+          expect(subject.to_s).to eq(
+            "https://people-staging.planningcenteronline.com/households/2.html?foo=bar&full_access=1&total_control=1"
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
There are occasions in the household manager in which the `_e` param is not the only param and is sometimes later in the list. Because of that, this regex was not matching since `_e` was not at the _beginning_ of the string.

This changes the regex to match on word boundaries which allows it to be at the front of the string but also with a `otherparam=stuff&_e=xxxxx`.