### PR TITLE
Prevent generating avatars-staging.planningcenteronline.com

### DIFF
--- a/lib/pco/url.rb
+++ b/lib/pco/url.rb
@@ -1,4 +1,5 @@
 require_relative "url/version"
+require_relative "url/avatars"
 require_relative "url/church_center"
 require_relative "url/get"
 require_relative "url/encryption"
@@ -30,6 +31,8 @@ module PCO
       def method_missing(method_name, *args)
         path = args.map { |p| p.sub(%r{\A/+}, "").sub(%r{/+\Z}, "") }.join("/")
         case method_name
+        when :avatars
+          PCO::URL::Avatars.new(path: path).to_s
         when :church_center
           PCO::URL::ChurchCenter.new(path: path).to_s
         when :get

--- a/lib/pco/url/avatars.rb
+++ b/lib/pco/url/avatars.rb
@@ -1,0 +1,13 @@
+module PCO
+  class URL
+    class Avatars < URL
+      def initialize(app_name: "avatars", path: nil, query: nil, encrypt_query_params: false, domain: nil)
+        super
+      end
+
+      def hostname
+        "#{app_name}.#{domain}"
+      end
+    end
+  end
+end

--- a/spec/pco_url_spec.rb
+++ b/spec/pco_url_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 APPLICATIONS = [
   :accounts,
-  :avatars,
   :services,
   :check_ins,
   :people,
@@ -37,6 +36,10 @@ describe PCO::URL do
       it "has a church-center url" do
         expect(PCO::URL.church_center).to eq("http://churchcenter.test")
       end
+
+      it "has an avatars url" do
+        expect(PCO::URL.avatars).to eq("http://avatars.pco.test")
+      end
     end
 
     describe "staging" do
@@ -57,6 +60,10 @@ describe PCO::URL do
 
       it "has a church-center url" do
         expect(PCO::URL.church_center).to eq("https://staging.churchcenter.com")
+      end
+
+      it "uses production for avatars because staging does not exist" do
+        expect(PCO::URL.avatars).to eq("https://avatars.planningcenteronline.com")
       end
     end
 
@@ -79,6 +86,10 @@ describe PCO::URL do
       it "has a church-center url" do
         expect(PCO::URL.church_center).to eq("https://churchcenter.com")
       end
+
+      it "has an avatars url" do
+        expect(PCO::URL.avatars).to eq("https://avatars.planningcenteronline.com")
+      end
     end
 
     describe "test" do
@@ -94,6 +105,10 @@ describe PCO::URL do
 
       it "has a church-center url" do
         expect(PCO::URL.church_center).to eq("http://churchcenter.test")
+      end
+
+      it "has an avatars url" do
+        expect(PCO::URL.avatars).to eq("http://avatars.pco.test")
       end
     end
   end


### PR DESCRIPTION
Today I learned that there is no routing for `avatars-staging.planningcenteronline.com`.

This can be confirmed by trying to visit these two URLs

- https://avatars.planningcenteronline.com/uploads/person/3370537-1366303802/avatar.4.jpg
- https://avatars-staging.planningcenteronline.com/uploads/person/3370537-1366303802/avatar.4.jpg

This matches our convention that production and staging share data.  Handle this special case when using `PCO::URL.avatars`