### PR TITLE
fix(Encryption): repair downcased encrypted params

### DIFF
--- a/lib/pco/url/encryption.rb
+++ b/lib/pco/url/encryption.rb
@@ -75,7 +75,7 @@ module PCO
 
         def decrypt(data, key: @default_key)
           raise MissingKeyError, "default key or key: argument must be set" if key.nil?
-          iv, encrypted = data.split("Z").map { |part| decode(part) }
+          iv, encrypted = case_corrected(data).split("Z").map { |part| decode(part) }
           raise DecryptError, "not a valid string to decrypt" unless iv && encrypted
           decrypter = cipher(:decrypt, key: key)
           decrypter.iv = iv
@@ -90,6 +90,11 @@ module PCO
         end
 
         private
+
+        def case_corrected(data)
+          return data unless data[26] == "z"
+          data.tr("a", "A").gsub(/([#{TABLE}]{26})z/, '\1Z')
+        end
 
         def chunks(str, size)
           result = []

--- a/spec/pco/url/encryption_spec.rb
+++ b/spec/pco/url/encryption_spec.rb
@@ -30,6 +30,16 @@ describe PCO::URL::Encryption do
 
         expect(described_class.decrypt(encrypted)).to eq("Horseman")
       end
+
+      context "when the encrypted string gets downcased for some dumb reason" do
+        it "decrypts correctly" do
+          described_class.default_key = TEST_DEFAULT_KEY
+          encrypted = described_class.encrypt("Butterscotch").downcase
+          decrypted = described_class.decrypt(encrypted)
+
+          expect(decrypted).to eq("Butterscotch")
+        end
+      end
     end
 
     context "when no default key is set" do


### PR DESCRIPTION
We get errors decrypting the param sometimes, and after some logging,
the culprit turns out to be user agents that downcase the URL.

Fortunately, we can detect this by checking whether the 27th character
in the string is an uppercase `Z`. If it isn't, then the string has been
downcased and needs to be repaired.

We repair it by upcasing _only_ that `z` (all other `z` characters
must remain lowercase), and also upcasing the `a` characters.