### PR TITLE
fix(Encryption): improve downcasing repair regex

### DIFF
--- a/lib/pco/url/encryption.rb
+++ b/lib/pco/url/encryption.rb
@@ -93,7 +93,7 @@ module PCO
 
         def case_corrected(data)
           return data unless data[26] == "z"
-          data.tr("a", "A").gsub(/([#{TABLE}]{26})z/, '\1Z')
+          data.tr("a", "A").sub(/\A([#{TABLE}]{26})z/, '\1Z')
         end
 
         def chunks(str, size)


### PR DESCRIPTION
1. Check from start of string.
2. Only `sub` (a single replacement) is necessary. `gsub` was causing
later `Z` characters also preceded by 26 characters to be upcased.