### PR TITLE
feat(Domain): use whatever domain is currently in use in dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# v2.0.2 (2013-01-21)
+# v2.1.0 (2019-11-05)
+
+* Feature: Add support in dev for any TLD [Tim Morgan]
+
+# v2.0.2 (2019-01-21)
 
 * Fix: Repair downcased encrypted params even better
 

--- a/lib/pco/url.rb
+++ b/lib/pco/url.rb
@@ -2,6 +2,7 @@ require_relative "url/version"
 require_relative "url/church_center"
 require_relative "url/get"
 require_relative "url/encryption"
+require_relative "url/engine"
 require "uri"
 
 module PCO
@@ -85,7 +86,7 @@ module PCO
       when "production", "staging"
         "planningcenteronline.com"
       when "development", "test"
-        "pco.test"
+        PCO::URL::Engine.domain || "pco.test"
       end
     end
 

--- a/lib/pco/url/engine.rb
+++ b/lib/pco/url/engine.rb
@@ -1,0 +1,13 @@
+require_relative "./engine/domain_middleware"
+
+module PCO
+  class URL
+    class Engine < Rails::Engine
+      thread_cattr_accessor :domain
+
+      initializer "pco_url.add_middleware" do |app|
+        app.middleware.use PCO::URL::Engine::DomainMiddleware if Rails.env.development? || Rails.env.test?
+      end
+    end
+  end
+end

--- a/lib/pco/url/engine.rb
+++ b/lib/pco/url/engine.rb
@@ -3,7 +3,13 @@ require_relative "./engine/domain_middleware"
 module PCO
   class URL
     class Engine < Rails::Engine
-      thread_cattr_accessor :domain
+      def self.domain
+        Thread.current[:pco_url_domain]
+      end
+
+      def self.domain=(d)
+        Thread.current[:pco_url_domain] = d
+      end
 
       initializer "pco_url.add_middleware" do |app|
         app.middleware.use PCO::URL::Engine::DomainMiddleware if Rails.env.development? || Rails.env.test?

--- a/lib/pco/url/engine/domain_middleware.rb
+++ b/lib/pco/url/engine/domain_middleware.rb
@@ -1,0 +1,16 @@
+module PCO
+  class URL
+    class Engine < Rails::Engine
+      class DomainMiddleware
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          PCO::URL::Engine.domain = env["SERVER_NAME"].downcase.match(/[a-z0-9-]+\.[a-z]+$/).to_s
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/pco/url/version.rb
+++ b/lib/pco/url/version.rb
@@ -1,5 +1,5 @@
 module PCO
   class URL
-    VERSION = "2.0.2".freeze
+    VERSION = "2.1.0".freeze
   end
 end

--- a/pco-url.gemspec
+++ b/pco-url.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rails", "~> 5.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", ">= 3.0.0", "< 4"
   spec.add_development_dependency "rubocop", "0.54.0"

--- a/pco-url.gemspec
+++ b/pco-url.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rails", "~> 5.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", ">= 3.0.0", "< 4"
+  spec.add_development_dependency "rspec-rails", "~> 3.9.0"
   spec.add_development_dependency "rubocop", "0.54.0"
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,0 +1,22 @@
+require_relative "./boot"
+require "action_controller/railtie"
+
+require 'pco/url'
+
+module Dummy
+  class Application < Rails::Application
+    config.eager_load = false
+  end
+end
+
+Dummy::Application.initialize!
+
+class TestsController < ActionController::Base
+  def show
+    render plain: PCO::URL.people
+  end
+end
+
+Rails.application.routes.draw do
+  resource :test
+end

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,0 +1,5 @@
+gemfile = File.expand_path('../../../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] = gemfile
+require 'bundler'
+Bundler.setup
+$LOAD_PATH.unshift(File.expand_path('../../../../lib', __FILE__))

--- a/spec/requests/dev_domain_spec.rb
+++ b/spec/requests/dev_domain_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe PCO::URL::Engine::DomainMiddleware, type: :request do
+  context "in development mode" do
+    before do
+      ENV["DEPLOY_ENV"] = Rails.env = "development"
+    end
+
+    it "sets the generated URL domain to be the same as the host" do
+      host! "accounts.pco.test"
+      get "/test"
+      expect(response.body).to eq("http://people.pco.test")
+      host! "accounts.pco.codes"
+      get "/test"
+      expect(response.body).to eq("http://people.pco.codes")
+    end
+  end
+
+  context "in test mode" do
+    before do
+      ENV["DEPLOY_ENV"] = Rails.env = "test"
+    end
+
+    it "sets the generated URL domain to be the same as the host" do
+      host! "accounts.pco.test"
+      get "/test"
+      expect(response.body).to eq("http://people.pco.test")
+      host! "accounts.pco.codes"
+      get "/test"
+      expect(response.body).to eq("http://people.pco.codes")
+    end
+  end
+
+  context "in staging mode" do
+    before do
+      ENV["DEPLOY_ENV"] = Rails.env = "staging"
+    end
+
+    it "does not change the domain based on host" do
+      host! "accounts.pco.test"
+      get "/test"
+      expect(response.body).to eq("https://people-staging.planningcenteronline.com")
+    end
+  end
+
+  context "in production mode" do
+    before do
+      ENV["DEPLOY_ENV"] = Rails.env = "production"
+    end
+
+    it "does not change the domain based on host" do
+      host! "accounts.pco.test"
+      get "/test"
+      expect(response.body).to eq("https://people.planningcenteronline.com")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "rspec"
+require "rails"
 require "pco/url"
 
 RSpec.configure do |config|
@@ -9,11 +10,5 @@ RSpec.configure do |config|
   def reset_encryption_default_key
     return unless PCO::URL::Encryption.instance_variable_defined?(:@default_key)
     PCO::URL::Encryption.remove_instance_variable(:@default_key)
-  end
-end
-
-class Rails
-  class << self
-    attr_accessor :env
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
-require "rspec"
 require "rails"
+require File.expand_path("dummy/config/application", __dir__)
+
+require "rspec"
+require "rspec/rails"
 require "pco/url"
 
 RSpec.configure do |config|


### PR DESCRIPTION
In order to simplify the `pco.dev` proxy,
and in order to work around the Safari bug with `.test` TLDs,
I'd like to add support for PCO::URL to generate a URL using the matching TLD in development.

My immediate goal is to PR this into all the apps and update pco-box so that `pco.codes` is an alternate domain for use in local development.