### PR TITLE
Always use pco.test in test environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.1.2 (2020-01-13)
+
+* Fix: Always use pco.test in test environment [Tim Morgan]
+
 # v2.1.1 (2019-12-10)
 
 * Chore: A bunch of maintenance [Shane Bonham]

--- a/lib/pco/url.rb
+++ b/lib/pco/url.rb
@@ -85,7 +85,9 @@ module PCO
       case env
       when "production", "staging"
         "planningcenteronline.com"
-      when "development", "test"
+      when "test"
+        "pco.test"
+      when "development"
         PCO::URL::Engine.domain || "pco.test"
       end
     end

--- a/lib/pco/url/version.rb
+++ b/lib/pco/url/version.rb
@@ -1,5 +1,5 @@
 module PCO
   class URL
-    VERSION = "2.1.1".freeze
+    VERSION = "2.1.2".freeze
   end
 end

--- a/spec/requests/dev_domain_spec.rb
+++ b/spec/requests/dev_domain_spec.rb
@@ -27,7 +27,7 @@ describe PCO::URL::Engine::DomainMiddleware, type: :request do
       expect(response.body).to eq("http://people.pco.test")
       host! "accounts.pco.codes"
       get "/test"
-      expect(response.body).to eq("http://people.pco.codes")
+      expect(response.body).to eq("http://people.pco.test")
     end
   end
 


### PR DESCRIPTION
### Summary

Many app tests were failing because the domain that pco-url sees is "example.com" for request specs. This change still lets the domain be whatever we want in development, but in the test env, we should stick to pco.test.

### Other Information

This PR and its predecessor #24 are in support of ministrycentered/pco-box#194. The reason we want this is so we can use any domain we want in development. Specifically, we want `pco.codes` to work like `pco.test`, since there is a bug in Safari's handling of cookies on `pco.test`.